### PR TITLE
fix:VO修改

### DIFF
--- a/src/main/java/com/foodietime/smg/model/SmgVO.java
+++ b/src/main/java/com/foodietime/smg/model/SmgVO.java
@@ -72,7 +72,7 @@ public class SmgVO implements Serializable {
     @OneToMany(mappedBy = "smg", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Set<SmgauthVO> smgauths;
     
-    @OneToMany(mappedBy = "smgrId", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "smgr", cascade = CascadeType.ALL)
     private List<DirectMessageVO> directMessages = new ArrayList<>();
     
     


### PR DESCRIPTION
由於框架規定manytoone的參數名稱不要有id,有id就改掉